### PR TITLE
Fix typo in 'get in touch' link

### DIFF
--- a/language-app/about.md
+++ b/language-app/about.md
@@ -1,3 +1,3 @@
 # Language App
 
-This lab has not yet started, but if you're interested in building a cross-platform mobile app using Dart and Flutter, then [get in touch!](https://wwww.kindservices.co.uk)
+This lab has not yet started, but if you're interested in building a cross-platform mobile app using Dart and Flutter, then [get in touch!](https://www.kindservices.co.uk)


### PR DESCRIPTION
Url was `wwww` instead of `www`.